### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 go get -u github.com/stephenlacy/go-ethereum-hdwallet
 ```
 
-## Documenation
+## Documentation
 
 [https://godoc.org/github.com/stephenlacy/go-ethereum-hdwallet](https://godoc.org/github.com/stephenlacy/go-ethereum-hdwallet)
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "Documenation" to "Documentation".

Please review the changes and let me know if any additional changes are needed.

