### PR TITLE
Add Validation for Missing Flags (mnemonic and hdpath) @ main.go

### DIFF
--- a/cmd/geth-hdwallet/main.go
+++ b/cmd/geth-hdwallet/main.go
@@ -16,6 +16,15 @@ func main() {
 	flag.StringVar(&hdpath, "path", "", "HD path")
 	flag.Parse()
 
+	// Check for empty values
+	if mnemonic == "" {
+		log.Fatal("Mnemonic phrase is required")
+	}
+
+	if hdpath == "" {
+		log.Fatal("HD path is required")
+	}
+
 	wallet, err := hdwallet.NewFromMnemonic(mnemonic)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
#### Summary:
This pull request adds checks to ensure that the required flags `mnemonic` and `hdpath` are provided before proceeding with the wallet creation and account derivation. If either of these flags is missing, an informative error message is displayed, preventing the program from continuing with invalid or empty values.

#### Issue:
The original code does not validate whether the `mnemonic` and `hdpath` flags have been set. As a result, if either flag is missing, the program could proceed with invalid values, potentially leading to confusing errors later in the execution.

#### Fix:
I added checks right after `flag.Parse()` to ensure that both the `mnemonic` and `hdpath` flags are provided. If either is missing, the program will log an error and exit gracefully with a clear message, as shown below:
```go
if mnemonic == "" {
	log.Fatal("Mnemonic phrase is required")
}

if hdpath == "" {
	log.Fatal("HD path is required")
}
```

#### Importance:
This change improves user experience by providing clear, early feedback when required flags are missing. It prevents the program from running with invalid input and ensures that the user is informed of the exact issue before any further processing. This validation enhances the robustness of the code and helps avoid unnecessary confusion, especially for users unfamiliar with the expected inputs.

Thank you for reviewing this change!
